### PR TITLE
fix notification job which was ignored due to duplicated jobs names 

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ looking. You've came to the right place.
         - chmod +x send.sh
         - ./send.sh success $WEBHOOK_URL
       when: on_success
-    success_notification:
+    failure_notification:
       stage: notification
       script:
         - wget https://raw.githubusercontent.com/DiscordHooks/gitlab-ci-discord-webhook/master/send.sh


### PR DESCRIPTION
fix notification job which was ignored due to duplicated jobs names 

the second job name is success_notification whereas it should be failure_notification

Fixes https://github.com/DiscordHooks/gitlab-ci-discord-webhook/issues/1