### PR TITLE
Link to artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GitLab CI 🡒 Discord Webhook
 [![Backers on Open Collective](https://opencollective.com/discordhooks/backers/badge.svg)](#backers)
- [![Sponsors on Open Collective](https://opencollective.com/discordhooks/sponsors/badge.svg)](#sponsors) 
+ [![Sponsors on Open Collective](https://opencollective.com/discordhooks/sponsors/badge.svg)](#sponsors)
 
 If you are looking for a way to get build (success/fail) status reports from
 [GitLab CI](https://gitlab.com) in [Discord](https://discordapp.com), stop
@@ -50,6 +50,19 @@ looking. You've came to the right place.
 
 1.  Grab your coffee ☕ and enjoy! And, if you liked this, please ⭐**Star**
     this repository to show your love.
+
+### Artifacts
+
+  If you'd like to also link the artifacts in the CI Message, set the variable LINK_ARTIFACT to true:
+
+  ```yaml
+  variables:
+    LINK_ARTIFACT: "true"
+  ```
+
+  Make sure that the artifacts are available to download in the ```success_notification``` job. If they are produced by a previous one, you can follow [this StackOverflow question](https://stackoverflow.com/questions/38140996/how-can-i-pass-artifacts-to-another-stage "this StackOverflow question")
+
+  Please also note that artifacts are only available, if ```success_notification``` has been triggered. 
 
 ### Note
 -  If you face any issues in the scripts (and you're sure it's not on your side),

--- a/send.sh
+++ b/send.sh
@@ -45,39 +45,71 @@ else
 fi
 
 TIMESTAMP=$(date --utc +%FT%TZ)
-WEBHOOK_DATA='{
-  "username": "",
-  "avatar_url": "https://gitlab.com/favicon.png",
-  "embeds": [ {
-    "color": '$EMBED_COLOR',
-    "author": {
-      "name": "Pipeline #'"$CI_PIPELINE_IID"' '"$STATUS_MESSAGE"' - '"$CI_PROJECT_PATH_SLUG"'",
-      "url": "'"$CI_PIPELINE_URL"'",
-      "icon_url": "https://gitlab.com/favicon.png"
-    },
-    "title": "'"$COMMIT_SUBJECT"'",
-    "url": "'"$URL"'",
-    "description": "'"${COMMIT_MESSAGE//$'\n'/ }"\\n\\n"$CREDITS"'",
-    "fields": [
-      {
-        "name": "Commit",
-        "value": "'"[\`$CI_COMMIT_SHORT_SHA\`]($CI_PROJECT_URL/commit/$CI_COMMIT_SHA)"'",
-        "inline": true
-      },
-      {
-        "name": "Branch",
-        "value": "'"[\`$CI_COMMIT_REF_NAME\`]($CI_PROJECT_URL/tree/$CI_COMMIT_REF_NAME)"'",
-        "inline": true
-      },
-      {
-        "name": "Artifacts",
-        "value": "'"[\`$CI_JOB_ID\`]($ARTIFACT_URL)"'",
-        "inline": true
-      }
-    ],
-    "timestamp": "'"$TIMESTAMP"'"
-  } ]
-}'
+
+if [ -z $LINK_ARTIFACT ] || [ $LINK_ARTIFACT = false ] ; then
+	WEBHOOK_DATA='{
+		"username": "",
+		"avatar_url": "https://gitlab.com/favicon.png",
+		"embeds": [ {
+			"color": '$EMBED_COLOR',
+			"author": {
+			"name": "Pipeline #'"$CI_PIPELINE_IID"' '"$STATUS_MESSAGE"' - '"$CI_PROJECT_PATH_SLUG"'",
+			"url": "'"$CI_PIPELINE_URL"'",
+			"icon_url": "https://gitlab.com/favicon.png"
+			},
+			"title": "'"$COMMIT_SUBJECT"'",
+			"url": "'"$URL"'",
+			"description": "'"${COMMIT_MESSAGE//$'\n'/ }"\\n\\n"$CREDITS"'",
+			"fields": [
+			{
+				"name": "Commit",
+				"value": "'"[\`$CI_COMMIT_SHORT_SHA\`]($CI_PROJECT_URL/commit/$CI_COMMIT_SHA)"'",
+				"inline": true
+			},
+			{
+				"name": "Branch",
+				"value": "'"[\`$CI_COMMIT_REF_NAME\`]($CI_PROJECT_URL/tree/$CI_COMMIT_REF_NAME)"'",
+				"inline": true
+			},
+			],
+			"timestamp": "'"$TIMESTAMP"'"
+		} ]
+	}'
+else
+	WEBHOOK_DATA='{
+		"username": "",
+		"avatar_url": "https://gitlab.com/favicon.png",
+		"embeds": [ {
+			"color": '$EMBED_COLOR',
+			"author": {
+			"name": "Pipeline #'"$CI_PIPELINE_IID"' '"$STATUS_MESSAGE"' - '"$CI_PROJECT_PATH_SLUG"'",
+			"url": "'"$CI_PIPELINE_URL"'",
+			"icon_url": "https://gitlab.com/favicon.png"
+			},
+			"title": "'"$COMMIT_SUBJECT"'",
+			"url": "'"$URL"'",
+			"description": "'"${COMMIT_MESSAGE//$'\n'/ }"\\n\\n"$CREDITS"'",
+			"fields": [
+			{
+				"name": "Commit",
+				"value": "'"[\`$CI_COMMIT_SHORT_SHA\`]($CI_PROJECT_URL/commit/$CI_COMMIT_SHA)"'",
+				"inline": true
+			},
+			{
+				"name": "Branch",
+				"value": "'"[\`$CI_COMMIT_REF_NAME\`]($CI_PROJECT_URL/tree/$CI_COMMIT_REF_NAME)"'",
+				"inline": true
+			},
+			{
+				"name": "Artifacts",
+				"value": "'"[\`$CI_JOB_ID\`]($ARTIFACT_URL)"'",
+				"inline": true
+			}
+			],
+			"timestamp": "'"$TIMESTAMP"'"
+		} ]
+	}'
+fi
 
 for ARG in "$@"; do
   echo -e "[Webhook]: Sending webhook to Discord...\\n";

--- a/send.sh
+++ b/send.sh
@@ -47,34 +47,34 @@ fi
 TIMESTAMP=$(date --utc +%FT%TZ)
 
 if [ -z $LINK_ARTIFACT ] || [ $LINK_ARTIFACT = false ] ; then
-	WEBHOOK_DATA='{
-		"username": "",
-		"avatar_url": "https://gitlab.com/favicon.png",
-		"embeds": [ {
-			"color": '$EMBED_COLOR',
-			"author": {
-			"name": "Pipeline #'"$CI_PIPELINE_IID"' '"$STATUS_MESSAGE"' - '"$CI_PROJECT_PATH_SLUG"'",
-			"url": "'"$CI_PIPELINE_URL"'",
-			"icon_url": "https://gitlab.com/favicon.png"
-			},
-			"title": "'"$COMMIT_SUBJECT"'",
-			"url": "'"$URL"'",
-			"description": "'"${COMMIT_MESSAGE//$'\n'/ }"\\n\\n"$CREDITS"'",
-			"fields": [
-			{
-				"name": "Commit",
-				"value": "'"[\`$CI_COMMIT_SHORT_SHA\`]($CI_PROJECT_URL/commit/$CI_COMMIT_SHA)"'",
-				"inline": true
-			},
-			{
-				"name": "Branch",
-				"value": "'"[\`$CI_COMMIT_REF_NAME\`]($CI_PROJECT_URL/tree/$CI_COMMIT_REF_NAME)"'",
-				"inline": true
-			},
-			],
-			"timestamp": "'"$TIMESTAMP"'"
-		} ]
-	}'
+  WEBHOOK_DATA='{
+    "username": "",
+    "avatar_url": "https://gitlab.com/favicon.png",
+    "embeds": [ {
+      "color": '$EMBED_COLOR',
+      "author": {
+        "name": "Pipeline #'"$CI_PIPELINE_IID"' '"$STATUS_MESSAGE"' - '"$CI_PROJECT_PATH_SLUG"'",
+        "url": "'"$CI_PIPELINE_URL"'",
+        "icon_url": "https://gitlab.com/favicon.png"
+      },
+      "title": "'"$COMMIT_SUBJECT"'",
+      "url": "'"$URL"'",
+      "description": "'"${COMMIT_MESSAGE//$'\n'/ }"\\n\\n"$CREDITS"'",
+      "fields": [
+        {
+          "name": "Commit",
+          "value": "'"[\`$CI_COMMIT_SHORT_SHA\`]($CI_PROJECT_URL/commit/$CI_COMMIT_SHA)"'",
+          "inline": true
+        },
+        {
+          "name": "Branch",
+          "value": "'"[\`$CI_COMMIT_REF_NAME\`]($CI_PROJECT_URL/tree/$CI_COMMIT_REF_NAME)"'",
+          "inline": true
+        }
+        ],
+        "timestamp": "'"$TIMESTAMP"'"
+      } ]
+    }'
 else
 	WEBHOOK_DATA='{
 		"username": "",

--- a/send.sh
+++ b/send.sh
@@ -4,16 +4,19 @@ case $1 in
   "success" )
     EMBED_COLOR=3066993
     STATUS_MESSAGE="Passed"
+    ARTIFACT_URL="$CI_JOB_URL/artifacts/download"
     ;;
 
   "failure" )
     EMBED_COLOR=15158332
     STATUS_MESSAGE="Failed"
+    ARTIFACT_URL="Not available"
     ;;
 
   * )
     EMBED_COLOR=0
     STATUS_MESSAGE="Status Unknown"
+    ARTIFACT_URL="Not available"
     ;;
 esac
 
@@ -27,6 +30,7 @@ AUTHOR_NAME="$(git log -1 "$CI_COMMIT_SHA" --pretty="%aN")"
 COMMITTER_NAME="$(git log -1 "$CI_COMMIT_SHA" --pretty="%cN")"
 COMMIT_SUBJECT="$(git log -1 "$CI_COMMIT_SHA" --pretty="%s")"
 COMMIT_MESSAGE="$(git log -1 "$CI_COMMIT_SHA" --pretty="%b")" | sed -E ':a;N;$!ba;s/\r{0,1}\n/\\n/g'
+
 
 if [ "$AUTHOR_NAME" == "$COMMITTER_NAME" ]; then
   CREDITS="$AUTHOR_NAME authored & committed"
@@ -63,6 +67,11 @@ WEBHOOK_DATA='{
       {
         "name": "Branch",
         "value": "'"[\`$CI_COMMIT_REF_NAME\`]($CI_PROJECT_URL/tree/$CI_COMMIT_REF_NAME)"'",
+        "inline": true
+      },
+      {
+        "name": "Artifacts",
+        "value": "'"[\`$CI_JOB_ID\`]($ARTIFACT_URL)"'",
         "inline": true
       }
     ],


### PR DESCRIPTION
Modified the script so that if you set `LINK_ARTIFACT` to true in the .gitlab-ci.yml, the Discord message will also contain a link for downloading the artifacts of the pipeline. Please note however, that the `success_notification` job has to have the artifacts available (as explained in the README)