### PR TITLE
Allow custom STATUS_MESSAGE

### DIFF
--- a/send.sh
+++ b/send.sh
@@ -3,19 +3,19 @@
 case $1 in
   "success" )
     EMBED_COLOR=3066993
-    STATUS_MESSAGE="Passed"
+    STATUS_MESSAGE="${STATUS_MESSAGE:-'Passed'}"
     ARTIFACT_URL="$CI_JOB_URL/artifacts/download"
     ;;
 
   "failure" )
     EMBED_COLOR=15158332
-    STATUS_MESSAGE="Failed"
+    STATUS_MESSAGE="${STATUS_MESSAGE:-'Failed'}"
     ARTIFACT_URL="Not available"
     ;;
 
   * )
     EMBED_COLOR=0
-    STATUS_MESSAGE="Status Unknown"
+    STATUS_MESSAGE="${STATUS_MESSAGE:-'Status Unknown'}"
     ARTIFACT_URL="Not available"
     ;;
 esac


### PR DESCRIPTION
### Changes
- This allows gitlab configurations to override the `STATUS_MESSAGE` to say something like `Passed Tests and Lint`, using bash's default var syntax.

### TODO
- Update the README. Would like some feedback on which part to update and what it should say. We can also pull this in and do another PR to update the README depending on how you feel about it.