### PR TITLE
Remove empty username field from WEBHOOK_DATA

### DIFF
--- a/send.sh
+++ b/send.sh
@@ -48,7 +48,6 @@ TIMESTAMP=$(date --utc +%FT%TZ)
 
 if [ -z $LINK_ARTIFACT ] || [ $LINK_ARTIFACT = false ] ; then
   WEBHOOK_DATA='{
-    "username": "",
     "avatar_url": "https://gitlab.com/favicon.png",
     "embeds": [ {
       "color": '$EMBED_COLOR',
@@ -77,7 +76,6 @@ if [ -z $LINK_ARTIFACT ] || [ $LINK_ARTIFACT = false ] ; then
     }'
 else
 	WEBHOOK_DATA='{
-		"username": "",
 		"avatar_url": "https://gitlab.com/favicon.png",
 		"embeds": [ {
 			"color": '$EMBED_COLOR',


### PR DESCRIPTION
Sending empty username string causes 400 error being returned from Discord API

```
{"username": ["Must be between 1 and 80 in length.", "Username cannot be \"\""]}
```