### PR TITLE
Fix HTTP 400 caused by empty username field

### DIFF
--- a/send.sh
+++ b/send.sh
@@ -48,7 +48,6 @@ TIMESTAMP=$(date --utc +%FT%TZ)
 
 if [ -z $LINK_ARTIFACT ] || [ $LINK_ARTIFACT = false ] ; then
   WEBHOOK_DATA='{
-    "username": "",
     "avatar_url": "https://gitlab.com/favicon.png",
     "embeds": [ {
       "color": '$EMBED_COLOR',
@@ -77,7 +76,6 @@ if [ -z $LINK_ARTIFACT ] || [ $LINK_ARTIFACT = false ] ; then
     }'
 else
 	WEBHOOK_DATA='{
-		"username": "",
 		"avatar_url": "https://gitlab.com/favicon.png",
 		"embeds": [ {
 			"color": '$EMBED_COLOR',


### PR DESCRIPTION
I've started receiving an HTTP 400 error when using the script, with the error:

```
{"username": ["Must be between 1 and 80 in length.", "Username cannot be \"\""]}
```

The fix is simple: Remove the `username` field from the data instead of passing an empty string.