### PR TITLE
Wrap true in quotes to make it a string in

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ looking. You've came to the right place.
 
   ```yaml
   variables:
-    LINK_ARTIFACT: true
+    LINK_ARTIFACT: "true"
   ```
 
   Make sure that the artifacts are available to download in the ```success_notification``` job. If they are produced by a previous one, you can follow [this StackOverflow question](https://stackoverflow.com/questions/38140996/how-can-i-pass-artifacts-to-another-stage "this StackOverflow question")


### PR DESCRIPTION
#### Summary of Changes

This pull request addresses the following modification:

- **Changed Configuration Variable:** `LINK_ARTIFACT`
  - **Before:** `"true"`
  - **After:** `true`

#### Description

We have updated the configuration of the `LINK_ARTIFACT` variable in our GitLab CI/CD pipeline. Previously, it was set as a string with the value `"true"`, and we have now changed it to a boolean with the value `true`.

#### Handling Configuration Errors

If you encounter the following error after merging this change:

```
Found errors in your .gitlab-ci.yml:
variables config should be a hash of key value pairs
value can be a hash
```